### PR TITLE
Add YAML frontmatter to skill files

### DIFF
--- a/plugins/project-coordinator/.claude-plugin/plugin.json
+++ b/plugins/project-coordinator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-coordinator",
   "description": "A Claude agent that coordinates multi-step projects by maintaining purpose, plans, and research logs, ensuring steady progress without owning scope, budget, or decisions.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "suzuki0keiichi"
   }

--- a/plugins/project-coordinator/skills/purpose-extraction.md
+++ b/plugins/project-coordinator/skills/purpose-extraction.md
@@ -1,7 +1,6 @@
 ---
 name: Purpose Extraction
 description: This skill should be used when the user asks to "clarify the goal", "what's the purpose", "why are we doing this", "extract the purpose", or mentions purpose clarification, goal alignment, or plan-purpose mismatch. Helps crystallize vague intentions into clear, actionable objectives.
-version: 1.1.0
 ---
 
 # Purpose Extraction Skill

--- a/plugins/project-coordinator/skills/purpose-extraction.md
+++ b/plugins/project-coordinator/skills/purpose-extraction.md
@@ -1,6 +1,6 @@
 ---
 name: Purpose Extraction
-description: This skill should be used when the user asks to "clarify the goal", "what's the purpose", "why are we doing this", "extract the purpose", or mentions purpose clarification, goal alignment, or plan-purpose mismatch. Helps crystallize vague intentions into clear, actionable objectives.
+description: This skill should be used when the user asks to "clarify the goal", "what's the purpose", "why are we doing this", "extract the purpose", "目的を明確にして", "なぜこれをやるの", "ゴールは何", or mentions purpose clarification, goal alignment, or plan-purpose mismatch. Helps crystallize vague intentions into clear, actionable objectives.
 ---
 
 # Purpose Extraction Skill

--- a/plugins/project-coordinator/skills/purpose-extraction.md
+++ b/plugins/project-coordinator/skills/purpose-extraction.md
@@ -1,3 +1,9 @@
+---
+name: Purpose Extraction
+description: This skill should be used when the user asks to "clarify the goal", "what's the purpose", "why are we doing this", "extract the purpose", or mentions purpose clarification, goal alignment, or plan-purpose mismatch. Helps crystallize vague intentions into clear, actionable objectives.
+version: 1.1.0
+---
+
 # Purpose Extraction Skill
 
 Purpose extraction: uncover the true objectives behind plans and actions. The expertise lies in asking the right questions to crystallize vague intentions into clear, actionable purposes.

--- a/plugins/project-coordinator/skills/purpose-guard.md
+++ b/plugins/project-coordinator/skills/purpose-guard.md
@@ -1,7 +1,6 @@
 ---
 name: Purpose Guard
 description: This skill should be used when the user asks to "manage this complex task", "track this project", "coordinate this work", "I keep losing track", "investigate this bug", or mentions project coordination, purpose tracking, or plan management. Provides orchestration for complex, uncertain tasks while maintaining focus on original objectives.
-version: 1.1.0
 ---
 
 # Purpose Guard Skill

--- a/plugins/project-coordinator/skills/purpose-guard.md
+++ b/plugins/project-coordinator/skills/purpose-guard.md
@@ -1,6 +1,6 @@
 ---
 name: Purpose Guard
-description: This skill should be used when the user asks to "manage this complex task", "track this project", "coordinate this work", "I keep losing track", "investigate this bug", or mentions project coordination, purpose tracking, or plan management. Provides orchestration for complex, uncertain tasks while maintaining focus on original objectives.
+description: This skill should be used when the user asks to "manage this complex task", "track this project", "coordinate this work", "I keep losing track", "investigate this bug", "このタスクを管理して", "進捗を追跡して", "迷子になってきた", "このバグを調査して", or mentions project coordination, purpose tracking, or plan management. Provides orchestration for complex, uncertain tasks while maintaining focus on original objectives.
 ---
 
 # Purpose Guard Skill

--- a/plugins/project-coordinator/skills/purpose-guard.md
+++ b/plugins/project-coordinator/skills/purpose-guard.md
@@ -1,3 +1,9 @@
+---
+name: Purpose Guard
+description: This skill should be used when the user asks to "manage this complex task", "track this project", "coordinate this work", "I keep losing track", "investigate this bug", or mentions project coordination, purpose tracking, or plan management. Provides orchestration for complex, uncertain tasks while maintaining focus on original objectives.
+version: 1.1.0
+---
+
 # Purpose Guard Skill
 
 Manage complex, multi-step projects. Maintain focus on original objectives while adapting plans.


### PR DESCRIPTION
Skills require frontmatter for proper registration. Added name, description,
and version fields to purpose-guard.md and purpose-extraction.md following
official best practices (trigger phrases + skill summary).

https://claude.ai/code/session_01TUAQwPEKRKZYxZgtPjtxcV