### PR TITLE
Fix skill directory structure to follow Agent Skills spec

### DIFF
--- a/plugins/project-coordinator/.claude-plugin/plugin.json
+++ b/plugins/project-coordinator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-coordinator",
   "description": "A Claude agent that coordinates multi-step projects by maintaining purpose, plans, and research logs, ensuring steady progress without owning scope, budget, or decisions.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": {
     "name": "suzuki0keiichi"
   }

--- a/plugins/project-coordinator/skills/purpose-extraction/SKILL.md
+++ b/plugins/project-coordinator/skills/purpose-extraction/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Purpose Extraction
+name: purpose-extraction
 description: This skill should be used when the user asks to "clarify the goal", "what's the purpose", "why are we doing this", "extract the purpose", "目的を明確にして", "なぜこれをやるの", "ゴールは何", or mentions purpose clarification, goal alignment, or plan-purpose mismatch. Helps crystallize vague intentions into clear, actionable objectives.
 ---
 

--- a/plugins/project-coordinator/skills/purpose-guard/SKILL.md
+++ b/plugins/project-coordinator/skills/purpose-guard/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Purpose Guard
+name: purpose-guard
 description: This skill should be used when the user asks to "manage this complex task", "track this project", "coordinate this work", "I keep losing track", "investigate this bug", "このタスクを管理して", "進捗を追跡して", "迷子になってきた", "このバグを調査して", or mentions project coordination, purpose tracking, or plan management. Provides orchestration for complex, uncertain tasks while maintaining focus on original objectives.
 ---
 
@@ -50,7 +50,7 @@ Manage complex, multi-step projects. Maintain focus on original objectives while
 ### 1. Initialize
 
 1. Check `.claude/project-coordinator/` for existing docs
-2. **purpose.md first**: Read existing. If missing or unclear, read `purpose-extraction.md` skill and apply it to clarify with user.
+2. **purpose.md first**: Read existing. If missing or unclear, read `purpose-extraction` skill and apply it to clarify with user.
 3. Create plan.md autonomously
 
 ### 2. Execute and Track


### PR DESCRIPTION
Skills must be in folder format with SKILL.md filename:
- skills/purpose-guard.md → skills/purpose-guard/SKILL.md
- skills/purpose-extraction.md → skills/purpose-extraction/SKILL.md

Also changed 'name' field to lowercase with hyphens as per spec.

https://claude.ai/code/session_017n6h8xuaSGi2QzhRyY5sEu