### PR TITLE
feat(graphrag-knowledge): レビュースキルを全知見タイプ活用型に再設計

### DIFF
--- a/plugins/graphrag-knowledge/.claude-plugin/plugin.json
+++ b/plugins/graphrag-knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "graphrag-knowledge",
   "description": "プロジェクトの永続知識グラフ(採用判断/却下案/制約/目的/リスク/運用知識/横断関心/File)を vault(Obsidian Markdown)を単一正本として安全に読み書きするスキル + CLI。雑な要求からでも触る領域の Decision/Risk/運用知識を漏れなく把握し、判断の経緯や影響波及を辿り、結論を永続化する。LLM は生クエリを書かず JSON in / mutation plan out のみ扱う。",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "author": {
     "name": "suzuki0keiichi"
   },

--- a/plugins/graphrag-knowledge/references/graph-review-method.md
+++ b/plugins/graphrag-knowledge/references/graph-review-method.md
@@ -1,19 +1,19 @@
 # Shared method for graph-backed review
 
 The foundation shared by the 3 skills `/graphrag-knowledge:graphrag-design-review` / `:graphrag-pr-review` / `:graphrag-review-doc`.
-The three look different but share one root: **"take a change (or proposal) as the starting point, reverse-lookup the graph, and check it at the concept altitude against the human's frame."**
+The three look different but share one root: **"take a change (or proposal) as the starting point, retrieve everything the graph knows about it — bound or not — and interrogate the change with every knowledge type, at the concept altitude, against the human's frame."**
 The only differences are input axis and output shape:
 
 | skill | input axis | timing | output |
 |---|---|---|---|
 | graphrag-design-review | design proposal / approach (knowledge axis = pre-implementation face) | plan / design time | advice (concept-altitude findings) |
-| graphrag-pr-review | change diff (crosscut axis + File = post-implementation face) | PR / diff time | findings (classified in 3 tiers) |
+| graphrag-pr-review | change diff (crosscut + knowledge axes + File = post-implementation face) | PR / diff time | findings (classified in 3 tiers) |
 | graphrag-review-doc | change diff (same as above) | before PR review | human-facing explanation doc (HTML) |
 
-> ※ The section numbers of this reference (§0–§5, including sub-numbers §1.5 / §2.5) are referenced from the SKILL.md of the 3 skills above. When you add / remove / reorder a section, update the referrers (each skill's "method §N" notation) accordingly.
+> ※ The section numbers of this reference (§0–§5, including sub-numbers §1.5 / §2.3 / §2.5) are referenced from the SKILL.md of the 3 skills above. When you add / remove / reorder a section, update the referrers (each skill's "method §N" notation) accordingly.
 
-pr-review and review-doc share **almost the same pipeline** (reverse lookup → forward-expansion coverage → concept delta). The difference is whether the output is findings or a doc.
-Only design-review reads on an axis leaning toward the knowledge axis (Goal/Decision/Constraint/Risk).
+pr-review and review-doc share **almost the same pipeline** (reverse lookup → semantic sweep → forward-expansion coverage → per-type interrogation). The difference is whether the output is findings or a doc.
+design-review has no diff to anchor on, so it skips the File-anchored steps (§1.5 / §2 / §2.5); its retrieval is an area `ask` plus the semantic sweep (§2.3, with the proposal as digest source). The per-type interrogation (§3) and the utilization accounting (§4) are common to all three.
 
 ---
 
@@ -28,6 +28,7 @@ These follow the design recorded in the vault (retrievable via `ask "グラフ�
 5. **Never grep.** "What concepts / history / traps / policies exist" is retrieved via `ask` / `evidence`. Do not read `vault/*.md` or `graphrag/*.ts` directly (conforming to SKILL.md's Anti-patterns).
    This is about the **knowledge-retrieval path**, whereas **reading the code under review (the diff, candidate Files) is in fact an obligation** (§2.5-3).
    Concluding findings from inside the graph alone produces a superficial review, so it is forbidden.
+6. **Every knowledge type earns its keep.** The vault does not only hold boundaries (Layer/Concern/Component) — it holds constraints, rejected options, operational burns, open risks, goals, and open questions. A review that checks boundaries and stops has wasted the rest. Retrieval (§2 + §2.3) must give every type a chance to surface, and interrogation (§3) must put a type-specific question to everything that surfaced — with the accounting (§4) proving it happened.
 
 ---
 
@@ -42,8 +43,9 @@ In a dev environment where the repo was cloned directly, `${CLAUDE_PLUGIN_ROOT}`
 
 Verbs used:
 - `ask "<question>"` — retrieve concepts / history / traps / policies in one shot (auto-escalation brief→evidence). **Do not repeat-fire.**
-  Query wording follows the parent skill's §Query discipline: **mix natural-language terms and code-language identifiers in one query** (knowledge is distilled in natural language while code uses English identifiers — using only one register narrows the hit surface). When the question alone is unlikely to hit, add `--gist "<expected one-liner answer>"`.
-- `evidence --request "<title/path>" [--types T] [--limit N] [--neighbors N]` — trace the neighborhood (governance / derivation) of a specific node.
+  Query wording follows the parent skill graphrag-knowledge's §Query discipline: **mix natural-language terms and code-language identifiers in one query** (knowledge is distilled in natural language while code uses English identifiers — using only one register narrows the hit surface). When the question alone is unlikely to hit, add `--gist "<expected one-liner answer>"`.
+- `evidence --request "<title/path>" [--types T1,T2] [--limit N] [--neighbors N]` — trace the neighborhood (governance / derivation) of a specific node, or sweep a type-scoped slice of the vault (§2.3).
+  `--types` takes a comma-separated list of **canonical** type names (e.g. `--types RejectedOption,OperationalKnowledge` — aliases like Vein/Pocket do not match).
   **Cannot be looked up by id** (id is excluded from the search target). Confirm the target node via direct_evidence's id / type, then read graph_context.
   Do not adopt results whose `match_confidence` is low/none.
 - `carving-check --graph <path> [--vector-index <path>]` — structural gate. In particular, watch **#9 knowledge-impl-binding-missing** (a policy not bound to an implementation).
@@ -51,13 +53,15 @@ Verbs used:
 
 ---
 
-## 1.5 Freshness precheck (before starting reverse lookup)
+## 1.5 Freshness precheck = anchor pass (one call per changed File, reused throughout)
 
 Reverse lookup (§2) implicitly assumes that "the changed Files are on the graph." If the index lags the diff,
-every subsequent step silently misses. So **before starting reverse lookup**, confirm that each File in the diff exists on the graph:
+every subsequent step silently misses. So **before anything else**, anchor each changed File on the graph — with the one call whose result §2 and §2.5 then read off:
 
-1. Look up each changed File via `evidence --request "<path of changed File>" --types File --limit 1` (same invocation as the impact-zone expansion in §2.5-1, so it is not double work).
-2. **If there is a File not present on the graph**: surface at the **head of the findings** — "the graph does not know this diff (the index is stale). Either run an incremental index / carve first, or explicitly note this File set as a review blind spot at the top." Do not silently skip.
+1. Per changed File: `evidence --request "<path of changed File>" --types File --limit 1 --neighbors 2`.
+   **Keep each result** — its depth-1/2 graph_context is the raw material of the frame (§2) and of the impact zone (§2.5-1). One call serves all three sections; re-firing it per section is waste, skipping a section because "the call was already made" is the opposite failure.
+2. **Confirm the anchor is real**: the returned direct_evidence node's `path` must equal the changed File's path. A fuzzy near-miss (a different File) counts as "not on the graph" — do not adopt a wrong File's neighborhood as this File's frame.
+3. **If there is a File not present on the graph**: surface at the **head of the findings** — "the graph does not know this diff (the index is stale). Either run an incremental index / carve first, or explicitly note this File set as a review blind spot at the top." Do not silently skip.
 
 The cause differs from the binding gap in §4: §4 is "the File is on the graph but no governing policy is bound" (binding gap →
 the prescription is bind completion via `edge-suggest-policy`); here it is "the File itself is not on the graph" (index lag → the prescription is incremental index/carve).
@@ -67,21 +71,26 @@ Conflating them routes the wrong prescription.
 
 ## 2. Skeleton of reverse lookup (shared procedure for pr-review / review-doc)
 
-Taking the changed File set as input, assemble the "frame" from the graph:
+Taking the changed File set as input, assemble the "frame" from the graph. Steps 2–4 are **read off the §1.5 anchor results** (the depth-1/2 graph_context already in hand) — the only new retrieval in this section is the single area-level `ask` of step 4:
 
 1. **Take the changed Files**: `git diff --name-only <base>...<head>` (or the current working diff).
-2. **Reverse-lookup the landing point** (crosscut axis): retrieve which **Layer (レイヤー) / Component (コンポーネント) / Concern (脈)** each changed File belongs to, via `ask` / `evidence`.
+2. **Landing point** (crosscut axis): from each anchor's depth-1 `evidenced_by` inflows, read which **Layer (レイヤー) / Component (コンポーネント) / Concern (脈)** the changed File belongs to.
    - Routing signals like "a change entered the UI Layer" surface here (changed File → interface/screen Layer or UI Component).
-3. **Reverse-lookup governance** (knowledge axis): retrieve the **Decision / Constraint / Risk / OperationalKnowledge that governs** that File / Component / Layer / Concern
-   (reverse direction of `sets_policy_for` / `constrains` / `risks_in` / `documented_by`).
+3. **Governance** (knowledge axis): read the **Decision / Constraint / Risk / OperationalKnowledge that governs** the File and its crosscut parents —
+   depth-1 holds the edges addressed directly to the File (`sets_policy_for` / `constrains` / `risks_in` / `documented_by` inflows); depth-2 holds the governance addressed to the crosscut parents **and to the depth-1 governance itself** (e.g. a Constraint that `constrains` the governing Decision) — area-altitude and knowledge-side policy arrives one hop later.
    = "What policies / constraints / risks is this area bound by."
-4. **Past history**: retrieve related **RejectedOptions** and `supersedes` chains, and `Investigation -led_to-> Decision`.
-   = "What has already been rejected here, and how each judgment came to be."
+4. **Past history**: around the governance nodes, read the `supersedes` / `rejected_in` / `led_to` edges (related **RejectedOptions**, and how each judgment came to be).
+   graph_context truncates (~10 edges/node, ~40 total; policy/lineage edge types are prioritized), so for the narrative it cannot carry, fire **one** area-level
+   `ask "<area topic + 1–2 code identifiers> の判断経緯・制約・却下案"` per area — not per node, and never repeatedly. If one specific node's thread is cut off, deep-dive it with a single `evidence --request "<node title>" --neighbors 1` (once or twice at most).
 5. **Confirm the live terminal (state)**: check the `supersedes` / `refines` chains and state of the retrieved nodes, and **build the frame from the live terminal**.
    **Do not use a Decision whose state is superseded as a reference point** (trace the successor via the reverse lookup of `refines`. Retrieval also de-scores terminal states
    superseded/closed/abandoned/achieved before returning, but does not exclude them — selecting the terminal is your own job here).
 
 The "frame" obtained from these 5 steps is the skeleton of the explanation doc and the baseline for concept-delta judgment.
+
+⚠ Reverse lookup travels **edges**, so it reaches only knowledge already **bound** to the changed Files or their crosscut parents.
+What governs the change but is not wired to it — a RejectedOption about the same approach, an unbound pitfall, a Goal — is invisible here **by construction**.
+Catching those is §2.3's job; do not let a rich-looking §2 frame talk you out of running the sweep.
 
 ### Concept word ↔ schema mapping (from human concept words to graph elements)
 
@@ -94,6 +103,34 @@ The "frame" obtained from these 5 steps is the skeleton of the explanation doc a
 | trap (罠) | Risk + OperationalKnowledge |
 | policy (方針) | Decision + Constraint (`sets_policy_for` / `constrains`) |
 | past history (過去経緯) | RejectedOption + `supersedes` chain + Investigation `led_to` |
+| direction (向かう先) | Goal (planned/active) + active Investigation |
+
+---
+
+## 2.3 Semantic sweep (approach axis — reaching knowledge the File anchor cannot)
+
+Reverse lookup finds what is **wired to the location**. But several knowledge types guard **approaches**, not locations, and are structurally invisible to §2:
+
+- **RejectedOption**: its natural edges (`rejected_in` → Investigation, ← `supersedes` from Decision) do not touch Files. Reintroduction is an **approach match, not a location match** — the same rejected mechanism can come back in a different file, where no reverse lookup will ever meet it.
+- **OperationalKnowledge**: pitfalls and workarounds are often procedural and weakly bound (or carry binding debt).
+- **Constraint**: `constrains` often targets a Decision — ≥2 hops from any File, beyond what neighbor expansion reliably returns (truncation at ~10 edges/node, ~40 total).
+- **Goal / active Investigation**: Goal has no File edges at all; Investigations rarely have them. Scope creep and open-question collision cannot surface from a File anchor.
+
+So after §2, sweep **from the content of the change itself**:
+
+1. **Distill two digests from the diff you have read** (1–2 lines each, following the parent skill graphrag-knowledge's query formula `<NL topic> + <1–2 code identifiers>`):
+   - **mechanism digest** — what mechanism / approach the change introduces or alters (e.g. "retry with exponential backoff in the sync client, hand-rolled queue in `syncQueue`").
+   - **intent digest** — what the change is trying to achieve (e.g. "make background sync survive flaky networks").
+2. **Guard sweep** (what must not be tripped):
+   `evidence --request "<mechanism digest>" --types RejectedOption,OperationalKnowledge,Constraint,Risk --limit 8 --neighbors 1`
+   Decision is deliberately absent from the list: it is the best-bound type (§2's main catch) and would crowd the ranked slots the sweep reserves for the types reverse lookup structurally misses.
+3. **Direction sweep** (where this should be heading):
+   `evidence --request "<intent digest>" --types Goal,Investigation --limit 5 --neighbors 1`
+   State matters here: an `abandoned` Goal hit is not noise — it is the roadmap counter-run signal (§3 Goal). For Investigation, only `active` ones raise the open-question flag; closed ones are history (their `led_to` Decisions are §2's territory).
+4. **Adoption**: drop matches whose `match_confidence` is low/none (at most one reworded retry per sweep — the same cutoff discipline as `ask`). Merge survivors into the §2 frame (dedupe by id). The merged set is the input of §2.5 and §3.
+5. **Two sweeps is the budget** (plus at most the one rewording each). Do not degenerate into repeat-firing.
+
+The sweep matches on embedding + lexical similarity, **independent of binding — that is the point.** A node the sweep finds that §2's reverse lookup missed is itself evidence of a **binding gap** (§4 diagnosis 1): the knowledge exists but is not wired to the implementation it governs. Record the pair (node, changed File) — it becomes the binding proposal in the write-back (§5).
 
 ---
 
@@ -103,20 +140,22 @@ Reverse lookup (§2) is a one-way trip "changed File → frame." The graph's tru
 **frame → File set → cross-check against the diff**. Without this, you can only see "whether the change crosses the frame," and
 **"whether the change missed siblings it should have touched within the frame" (incompleteness of the change)** slips through.
 
-1. **Impact-zone expansion**: with the changed File as seed, retrieve via `evidence --request "<path of changed File>" --types File --limit 1 --neighbors 2`.
-   **neighbors must be 2** (depth1 = the owning Concern/Component/Layer and policy edges addressed directly to the File; depth2 = sibling Files. 1 does not reach the siblings).
-   Pin the seed to the changed File with `--types File --limit 1` (a fuzzy match lets the neighborhood of unrelated nodes contaminate the impact zone).
+1. **Impact-zone expansion**: reuse the §1.5 anchor result of each changed File (`--types File --limit 1 --neighbors 2` — already fired once; do not re-fire).
+   **neighbors 2 is what makes this work** (depth1 = the owning Concern/Component/Layer and policy edges addressed directly to the File; depth2 = sibling Files. 1 does not reach the siblings).
+   The seed is pinned by `--types File --limit 1` and verified by the path check of §1.5-2 (a fuzzy match would let the neighborhood of unrelated nodes contaminate the impact zone).
    Neighbor expansion returns all touching edges in **both directions**, so coverage is machine-guaranteed (dedupe edges duplicated across depths before counting).
-   If `match_confidence` is low/none, do not adopt graph_context as the impact zone (one alternate keyword → if still no good, treat as the binding gap of §4).
+   A File whose anchor failed §1.5 is already a declared blind spot — its impact zone is unknowable; write that into the coverage accounting (6) instead of guessing.
    What to read:
    - The `evidenced_by` File set of the owning **Concern / Component / Layer** (depth2) = sibling Files in the same Concern / Component / Layer.
    - Other destinations of the `sets_policy_for` / `constrains` / `risks_in` of the governing **Decision / Constraint / Risk**.
-     If the destination is a crosscut structure (`sets_policy_for` / `risks_in` only. **The destination of `constrains` is File-only**), expand one more step via `evidenced_by` (chain expansion).
+     If the destination is a crosscut structure (possible for `sets_policy_for` / `risks_in` only — `constrains` never targets a crosscut structure; its destinations are Decision / File / OperationalKnowledge), expand one more step via `evidenced_by` (chain expansion).
+     A `constrains` → Decision destination propagates instead through that Decision's own `sets_policy_for` set (already at depth-2 of the anchor).
+   - Governance surfaced by the §2.3 sweep participates too: its `sets_policy_for` / `constrains` / `risks_in` destinations are already in the sweep's own graph_context (`--neighbors 1`) — fold them into the same cross-check, no extra calls needed.
 2. **Cross-check**: expanded File set − changed File set = **candidate Files that are within the impact zone but absent from the diff**.
 3. **Corroborate the candidates (mandatory — do not conclude inside the graph)**: for each candidate File, whether you turn it into a finding or drop it, pass this first:
    - **Retrieve the governance that governs the candidate**: `evidence --request "<path of candidate>" --types File --limit 1 --neighbors 1`.
      This per-candidate lookup is **unconditionally mandatory as the sole path to reach low-altitude bind (Constraint / policy edges addressed directly to the File)**.
-     It is a procedure that survives even if the destination of `constrains` is expanded in the future (**deleting this procedure is forbidden**).
+     It is a procedure that survives even if the destinations of `constrains` are expanded to crosscut structures in the future (**deleting this procedure is forbidden**).
    - **Actually read the candidate File and the relevant location in the diff**. The graph is a chain index for "where to look," not judgment material.
      Settling for "impact presence to be confirmed" without reading is forbidden (the grep ban of §0-5 is about "retrieving concepts / history from the vault."
      Reading the code under review is an obligation).
@@ -160,56 +199,85 @@ do not conclude "the impact zone is empty" — first suspect the possibility of 
 
 ---
 
-## 3. Concept-delta judgment (the core of pr-review / the annotation source for review-doc)
+## 3. Per-type interrogation (the core of pr-review / the annotation source for review-doc)
 
-Against the "frame" obtained from reverse lookup, check whether the change crosses the frame. Perspectives:
+The frame (§2 ∪ §2.3 ∪ §2.5) is not a backdrop. **Every node in it gets interrogated with its type's questions below, against the diff hunks you actually read**
+(graph summaries alone are not judgment material — the same reading obligation as §2.5-3). A node may be dropped as irrelevant only with a one-line reason in the accounting (§4).
+Checking the crosscut boundary and stopping is the failure mode this section exists to prevent: **the boundary checks are one entry in this list, not the list.**
 
-- **Rejected-option reintroduction**: does the change revive the same approach as a past RejectedOption (matching name / gist).
-- **Layer violation (Layer)**: do the imports after the change run backward against the vertical position of dependency (a lower layer depending on an upper one).
-- **Implicit breach of a Decision**: does it break, without stating so, the intent of a Decision that governs the area.
-- **Concern bleed-out / norm vs actual**: against a crosscut node's summary (= norm / design intent), has the post-change actual (evidenced_by) drifted.
-  Example: the norm of the error-handling Concern is "surface to the user + retry," but the new path only logs → it has left the Concern.
-- **Governance violation**: does the change satisfy the area's Constraint / established policy.
-  Example: in an area with policies "errors surface to the user (N-failures UI)" and "there is a retry mechanism," an addition that only does catch+log → policy regression.
-- **scope creep**: a change not tied to any Goal (is it a detour / running counter to where it is headed).
-- **has_premise reverse lookup (propagation of a broken premise)**: reverse-lookup and enumerate the **live nodes** that `has_premise` on a Decision that the change breaches/supersedes.
-  The has_premise inflow edges into the old node stay alive as lineage preservation — precisely because of that, unless you explicitly enumerate the "nodes that survive with a broken premise,"
-  the propagation stays invisible.
-- **reduces_risk release**: a Risk that a Decision the change weakens/breaches had been `reduces_risk`-ing **reopens**.
-  Surface the Risk whose suppression has been removed as a finding.
-- **OperationalKnowledge re-stepping**: does the change nullify a known pitfall / workaround (OperationalKnowledge),
-  or reintroduce a hole stepped into in the past.
-- **carving.json exemption addition**: if the diff includes a change to `.graphrag/carving.json`, **escalate the exemption addition into findings for
-  human adjudication** (carving.json is a human-owned concept layer on par with Layer/Concern/Component. The LLM may only propose; appending happens after user approval).
-- **Concept delta outside the perspective list**: if you notice a concept-level drift that fits none of the above, do not suppress it —
-  surface it explicitly with the same manner as an "out-of-graph finding" (state its provenance; see the escalation rules below).
+Questions per type (default tier in brackets; the escalation rules below apply on top):
+
+- **Constraint — the invariant** [violation = ACK-required]:
+  State the invariant concretely, then actively search the diff for a hunk that breaks it **or weakens its enforcement** (validation removed, check made bypassable, error path silenced — all count).
+  A Constraint is an immutable external condition — code cannot renegotiate it. Also check the reverse: does the change erode a premise the Constraint's enforcement rests on?
+- **RejectedOption — the guard against round trips** [reintroduction = ACK-required]:
+  Compare **approaches, not locations**: does any hunk re-implement the rejected mechanism (matching name / gist)? On a hit, quote the original rejection reason and its `rejected_in` Investigation,
+  and demand **"why is it different this time"** — a deliberate re-try must answer the old failure mode, not ignore it.
+- **Decision — the live policy** [implicit breach = advisory; escalate on real harm]:
+  Does the change preserve the decision's **intent**, not just its letter? Typical silent breaches: a new code path that bypasses the decided mechanism, partial adoption that leaves the old way alive, a flipped default.
+  Interrogate only the **live leaf** (§2-5); a superseded Decision is history, not policy — but a hunk that resurrects a superseded policy is a finding (lineage says it was retired deliberately).
+- **OperationalKnowledge — the recorded burn** [re-stepping = advisory; escalate if the pitfall is destructive]:
+  Two directions, both mandatory: (a) **re-stepping** — does the diff step into the documented pitfall, or undo the documented workaround (delete it, bypass it, "clean it up")?
+  (b) **conformance** — when the OK records the sanctioned way of doing exactly what the diff is doing, does the diff follow it?
+- **Risk — the open threat** [exposure increase = advisory; escalate on real harm]:
+  Does the change enlarge the risk's surface in its `risks_in` area? And reverse-lookup `reduces_risk` into the Risk: if the diff weakens or removes a mitigating Decision/OK,
+  the suppression is lifted and the Risk **reopens** — surface the released Risk itself as the finding, not just the edit that released it.
+- **Goal — the direction** [scope creep / counter-run = advisory]:
+  Which live Goal (planned/active) does this change serve? None → scope creep (a detour, or work nobody asked the system to head toward).
+  Toward an `abandoned` Goal, or against an active one → roadmap counter-run. Goals rarely surface from the File anchor (no File edges; at best depth-2 via a Decision's `has_premise`) — the §2.3 direction sweep is their main entrance, so an empty Goal row in the accounting with no sweep run is a §4 violation, not "no goals".
+- **Investigation (active) — the open question** [collision = advisory]:
+  The diff touches the subject of an open inquiry: surface it — the author may be blind to in-flight findings, and the change may invalidate the investigation's premise mid-flight.
+  Conversely, if the diff **settles** the question, say so and propose closing it in the write-back (§5).
+- **Layer / Concern / Component — the crosscut frame**:
+  - **Layer violation** [ACK-required]: do the imports after the change run backward against the vertical position of dependency (a lower layer depending on an upper one)?
+  - **Concern bleed-out / norm vs actual** [advisory]: against the crosscut node's summary (= norm / design intent), has the post-change actual (evidenced_by) drifted?
+    Example: the norm of the error-handling Concern is "surface to the user + retry," but the new path only logs → it has left the Concern.
+  - **Component responsibility drift** [advisory]: the change quietly re-scopes what the Component is for (its summary no longer tells the truth about it). Sibling coverage itself is §2.5's job, not this one.
+- **Cross-type propagation** (run once over the whole frame, not per node):
+  - **has_premise reverse lookup (propagation of a broken premise)** [advisory; escalate on real harm]: reverse-lookup and enumerate the **live nodes** that `has_premise` on a Decision that the change breaches/supersedes.
+    The has_premise inflow edges into the old node stay alive as lineage preservation — precisely because of that, unless you explicitly enumerate the "nodes that survive with a broken premise," the propagation stays invisible.
+- **carving.json exemption addition** [ACK-required — human adjudication]: if the diff includes a change to `.graphrag/carving.json`, escalate the exemption addition into findings
+  (carving.json is a human-owned concept layer on par with Layer/Concern/Component. The LLM may only propose; appending happens after user approval).
+- **Concept delta outside the protocol / out-of-graph finding** [red band, explicitly marked]: a concept-level drift that fits no entry above, or a high-confidence pure defect with no norm node —
+  do not suppress it; surface it explicitly marked **"out-of-graph finding"** (state its provenance; the exception to the traceable principle is made noisy, not hidden).
 
 ### 3-tier strength (classification of findings)
 
 | tier | what qualifies | behavior |
 |---|---|---|
 | **ERROR** | breakage of the graph's internal integrity (type-pair violation etc.). The `carving-check` / `validateGraph` domain | (rare in review) reject as structure |
-| **ACK-required** | machine can detect the divergence with high precision but the fix direction is human-adjudicated: **rejected-option reintroduction / layer violation / Constraint violation**. + findings escalated by severity (below) | does not reject but **stops and prompts approval** (red banner) |
-| **advisory** | LLM-judgment cases: Concern bleed-out / implicit breach of a Decision / governance regression / scope creep / **impact-zone missed siblings (§2.5 coverage check)** | display only (mention in context; the coverage check is an independent section) |
+| **ACK-required** | machine can detect the divergence with high precision but the fix direction is human-adjudicated: **rejected-option reintroduction / layer violation / Constraint violation / carving.json exemption**. + findings escalated by severity (below) | does not reject but **stops and prompts approval** (red banner) |
+| **advisory** | LLM-judgment cases: implicit breach of a Decision / OK re-stepping / Risk-exposure increase / scope creep / open-Investigation collision / Concern bleed-out / Component drift / **impact-zone missed siblings (§2.5 coverage check)** | display only (mention in context; the coverage check is an independent section) |
 
 **The tier is the default per detection path, not a ceiling (escalation allowed / de-escalation not allowed)**: even an advisory-band finding, if it crosses with a governing
-Constraint / Concern norm / Risk and you can judge "real harm results (it breaks / a hole opens / a premise is broken)," should be
+Constraint / Concern norm / Risk and you can judge "real harm results (it breaks / a hole opens / a premise is broken / a suppressed Risk reopens)," should be
 **escalated to ACK-required** and made noise with a red band. A pure defect finding with no norm node must also not be suppressed — surface it in the red band with "out-of-graph finding"
 stated explicitly (do not hide the exception to the traceable principle). The no-hard-reject principle (§0-2) does not change after escalation —
 making noise goes only as far as "stop and confirm"; the fix-direction ruling stays with the human.
 
-**This kind of policy regression (the error-visibility example) is the advisory band**. It is a semantic judgment, and at the sub-File granularity of a catch block, so it does not become a machine stop. But by laying out the policy in the explanation doc, it is reliably put in front of the human (and the reviewing LLM).
+**Semantic regressions at sub-File granularity (the error-visibility example) default to the advisory band — even when the governing node is a Constraint.** A catch block that quietly stops surfacing errors is an LLM judgment, not a machine stop: a *suspected* regression is advisory; the ACK row's "Constraint violation" is for the *confirmed* case. By laying the governing policy out next to the hunk, the suspicion is reliably put in front of the human (and the reviewing LLM) — and once you can state with confidence that the invariant is actually broken, the escalation rule above takes it to the red band.
 
 ---
 
-## 4. Self-check of whether the premise is satisfied (important)
+## 4. Knowledge-utilization accounting and gap diagnosis (important)
 
-If reverse lookup (steps 2-3) surfaced **not a single knowledge node governing the area**, that likely means not "there is no frame" but
-**"the frame is not bound to the area"** (= `carving-check` #9 knowledge-impl-binding-missing).
-Even if the policy exists in the vault, if it is not connected to the implementation File via `sets_policy_for` / `constrains`, it does not surface in reverse lookup = it slips through review.
+The review ends with an accounting that makes under-use of the graph visible, and a diagnosis for every hole. This generalizes the old "frame self-check": not just "did *anything* surface" but "did **each type** get its chance, and what does an empty row mean."
 
-- On detecting this state, state in the finding: **"this area has no governing policy on the graph (suspected binding gap). Retrieve candidates via `edge-suggest-policy` and bind the policy so it is picked up next time."**
-- Do not silently conclude "no policy." A silent binding gap is exactly the essence of why a policy regression slipped through in the past (see the regression case in the vault record: `ask "エラー可視化の退行"`).
+**Accounting (an independent section of the output)** — one line per knowledge type
+(Decision / Constraint / RejectedOption / OperationalKnowledge / Risk / Goal / Investigation / crosscut Layer·Concern·Component):
+`pulled N (§2: a / §2.3: b) / interrogated M / findings K / dropped with one-line reasons`.
+**"Nothing applicable" may be written only with this accounting attached** — the same structural block as §2.5-6: zero retrieval work must never be writable as "none".
+
+**Diagnosis of a 0-pulled type** — "pulled 0" is a fact about retrieval, not about the vault. Distinguish three causes and state which one you suspect:
+
+1. **Binding gap** — the knowledge exists but is not wired to the implementation it governs (= `carving-check` #9 knowledge-impl-binding-missing).
+   Signature: **the §2.3 sweep hits a node that §2's reverse lookup missed** (the sweep is binding-independent, so the discrepancy localizes the missing edge).
+   Prescription: state in the finding "this area has no governing policy bound on the graph (suspected binding gap). Retrieve candidates via `edge-suggest-policy` and bind the policy so it is picked up next time," and carry the (node, changed File) pair into the write-back (§5).
+   Do not silently conclude "no policy." A silent binding gap is exactly the essence of why a policy regression slipped through in the past (see the regression case in the vault record: `ask "エラー可視化の退行"`).
+2. **Retrieval gap** — the digest's vocabulary missed it. The one reworded retry (§2.3-4) is the only permitted retry; past that, state the residual blind spot honestly instead of re-firing.
+3. **Genuine absence** — the vault has never recorded this type for this area. That is itself reviewable information: if the area plainly deserves a guard of that type
+   (e.g. an auth-touching diff with zero recorded Constraints), say so in the findings. And if the review itself surfaced a judgment / constraint / burn worth keeping,
+   propose capturing it in the write-back (§5) — the review is not only a consumer of the graph; it is where the graph learns what it was missing.
 
 ---
 
@@ -217,10 +285,13 @@ Even if the policy exists in the vault, if it is not connected to the implementa
 
 - **Always attach the supporting node id to a finding** (traceable principle). Example: `⚠ [advisory] suspected regression of the error-visibility policy (constraint:...:errors-surface-to-user)`.
 - **Vary the prominence by tier**: ACK-required goes gathered at the top and made prominent; advisory is attached at the relevant location.
+- **Emit the knowledge-utilization accounting (§4) as its own section** (pr-review / review-doc; design-review's per-type accounting is the same obligation in its own output shape), alongside the §2.5 coverage-check section.
 - **A non-assertive ruling**: leave the fix-direction choice to the human — "possibly crossing the frame. Whether to fix the code, or to update the policy (graph) side and approve the intent change, is for the human to decide."
 - **Write-back of the resolution (preventing review alarm fatigue)**: when a human resolves an ACK-required finding by "approving the intent change,"
   propose the approved intent change as a mutation — an update to the Decision (state update etc.), the policy-reversal recipe
   (create a new Decision, wire it to the old via `refines`, update the old to state superseded. If the option discarded by the reversal could re-tempt, also attach a
-  RejectedOption), or a new RejectedOption — and connect it to the write-back of the graphrag-knowledge skill.
+  RejectedOption), or a new RejectedOption — and connect it to the write-back of the graphrag-knowledge skill. The same channel also carries the review's other harvest:
+  **binding proposals for §4-diagnosed gaps** (from `edge-suggest-policy` candidates or the §2.3 sweep-vs-§2 discrepancy pairs), **closing an active Investigation the diff settled** (§3 Investigation),
+  and **new knowledge the review surfaced in a genuinely-absent area** (§4 diagnosis 3).
   **If you do not update the graph, the same finding recurs at the next review and the ACK becomes a ritual (review alarm fatigue)**.
   Do not end at approval; only once you make the graph side follow the post-approval reality can it be called resolved.

--- a/plugins/graphrag-knowledge/skills/graphrag-design-review/SKILL.md
+++ b/plugins/graphrag-knowledge/skills/graphrag-design-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: graphrag-design-review
-version: 1.2.1
-description: 設計案や approach を、コードを書く前にグラフ（プロジェクトの永続知識）と照合してレビューする AI 設計レビュー。「実装前にこの方針でいい?」「この設計どう思う」「この approach を見て」と、実装に入る前の設計・計画の是非や、過去判断・制約との整合・roadmap との親和性を確認したい時に使う。実装後の diff レビューは graphrag-pr-review、人間向けの説明資料は graphrag-review-doc。スラッシュ: /graphrag-knowledge:graphrag-design-review
+version: 1.3.0
+description: 設計案や approach を、コードを書く前にグラフ（プロジェクトの永続知識）と照合してレビューする AI 設計レビュー。過去の Decision・Constraint・却下案 (RejectedOption)・運用知識 (OperationalKnowledge)・Risk・Goal・進行中 Investigation の全知見タイプに proposal を尋問する。「実装前にこの方針でいい?」「この設計どう思う」「この approach を見て」と、実装に入る前の設計・計画の是非や、過去判断・制約との整合・roadmap との親和性を確認したい時に使う。実装後の diff レビューは graphrag-pr-review、人間向けの説明資料は graphrag-review-doc。スラッシュ: /graphrag-knowledge:graphrag-design-review
 ---
 
 # Design Review (pre-implementation, knowledge axis)
@@ -11,7 +11,8 @@ and domain boundaries are cruel to "redo" at diff time, so review them here, bef
 
 For the shared foundation, CLI invocation, and invariants (never hard-reject / traceable / no grep, etc.),
 **you must first read `${CLAUDE_PLUGIN_ROOT}/references/graph-review-method.md`**. This skill documents only
-the procedure specific to its "knowledge axis (pre-implementation face)".
+the procedure specific to its "knowledge axis (pre-implementation face)". There is no diff yet, so the
+File-anchored steps (method §1.5 / §2 / §2.5) do not apply — retrieval is the area `ask` plus the semantic sweep (§2.3).
 
 ## Input
 
@@ -25,24 +26,24 @@ The design proposal / approach / plan under review. If `$ARGUMENTS` carries a de
    ```
    - Include in the query both the proposal's domain words (natural language) and concrete code identifiers the proposal touches (file / component / function names) — method §1 query discipline. A single-register query narrows the hit surface.
    - Do not fire repeatedly. If needed, deep-dive a specific node's neighborhood with `evidence --request "<node title or path>"` just once or twice (evidence cannot be looked up by id — method §1; confirm the target via direct_evidence's id/type, then read graph_context).
-2. **Perspectives to check against** (high-altitude perspectives that matter before implementation):
-   - **Implicit breach of an existing Decision**: is the proposal silently breaking the intent of a settled decision in that area, without saying so?
-   - **Rejected-option reintroduction**: is the proposal the same approach as a past RejectedOption (= a past guard; if reconsidering, demand "why is it different this time")?
-   - **Constraint violation**: is it breaking a constraint that must be upheld?
-   - **has_premise reverse lookup (premise-breaking propagation)**: reverse-look-up the
-     **live nodes** that `has_premise` onto a Decision the proposal breaches/supersedes, and check whether any
-     survive with a broken premise (has_premise onto old nodes lives on for lineage preservation, so the
-     propagation is invisible unless you enumerate them).
-   - **roadmap affinity**: relative to where we are headed (Goals whose status is planned/active), is it a detour/regression, or in a withdrawal direction (abandoned)?
+2. **Semantic sweep** — execute method §2.3 with **the proposal itself as the digest source** (no diff exists yet):
+   distill the proposal's **mechanism digest** (what mechanism/approach it introduces) and **intent digest** (what it is trying to achieve), then fire the guard sweep
+   (`--types RejectedOption,OperationalKnowledge,Constraint,Risk`) and the direction sweep (`--types Goal,Investigation`) once each.
+   The area `ask` of step 1 anchors on the *area*; the sweep anchors on the *approach* — a RejectedOption or an operational burn about the same mechanism in a different area surfaces only here.
+3. **Interrogate per type** — execute method §3 with "the diff" read as "the proposal": every node from step 1 ∪ step 2 gets its type's questions
+   (Constraint = would the proposal break or weaken the invariant / RejectedOption = same approach as a past rejection, demand "why is it different this time" /
+   Decision = silent breach of a settled intent / OperationalKnowledge = does the plan re-step a recorded burn or ignore the sanctioned way /
+   Risk = does it grow exposure or plan to remove a mitigation (the suppressed Risk reopens) / Goal = scope creep, roadmap counter-run /
+   active Investigation = collides with or settles an open question / has_premise reverse = which live nodes survive with a broken premise if the proposal supersedes a Decision).
+   Perspectives specific to this pre-implementation face, on top of §3:
    - **proportionality (magnitude)**: is the change excessive/insufficient relative to the target system's posture (lifespan/importance/maturity)? posture acts as a global gain that recalibrates the weight of every perspective.
-   - **scope creep**: is the proposal untied to any Goal?
-3. **When no frame can be drawn**: if no knowledge node governing the area surfaces, per method §4
-   state in the findings the "suspected frame not bound to the area" (point to `edge-suggest-policy`). Do not silently call it "no policy".
+4. **Accounting + gap diagnosis** — method §4 in this skill's output shape: per knowledge type, record "pulled N (ask / sweep) / interrogated M / findings K".
+   **"Nothing applicable" may be written only with accounting attached** (structurally blocking writing "none" with zero pulling work).
+   For a 0-pulled type, state the three-way diagnosis (binding gap → point to `edge-suggest-policy` / retrieval gap / genuine absence). Do not silently call it "no policy".
 
 ## Output
 
-- Per perspective, advice **with the supporting node id attached**. Not an assertion but the form "possible frame crossing; whether to change the code or update the policy side to approve the intent change is for the human to decide".
-- **Accounting**: per perspective, record the "number of nodes pulled". **"Nothing applicable" may be written only with accounting attached**
-  (structurally blocking writing "none" with zero pulling work).
+- Per type, advice **with the supporting node id attached**. Not an assertion but the form "possible frame crossing; whether to change the design or update the policy side to approve the intent change is for the human to decide".
 - Surface severe divergences (rejected-option reintroduction, Constraint violation) prominently at the top as **ACK-required**; attach the rest as advisory.
-- Finally, offer a one-line suggestion of "if this design is adopted, what should be left in the vault as Decision/RejectedOption" (connecting to the graphrag-knowledge skill's write-back).
+- Include the per-type accounting (step 4) so the review provably consulted every knowledge type, not just the ones the area query happened to return.
+- Finally, offer a one-line suggestion of "if this design is adopted, what should be left in the vault as Decision/RejectedOption" — and, if the proposal settles an active Investigation surfaced in step 2, note that it can be closed (connecting to the graphrag-knowledge skill's write-back).

--- a/plugins/graphrag-knowledge/skills/graphrag-knowledge/SKILL.md
+++ b/plugins/graphrag-knowledge/skills/graphrag-knowledge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: graphrag-knowledge
-version: 4.9.1
+version: 4.9.2
 description: プロジェクトの永続的な設計知識 (採用判断/却下案/制約/目的/リスク/運用知識と、それらを貫く横断構造) を vault を単一正本に安全に読み書きする。作業の最上流と一段落で発火する。【読み — 着手前に先に引く (コードやファイルを読む前にこれを起動)】① 「○○を実装/修正/改善/リファクタしたい」「○○がバグってる/動かない/エラー」「○○周りを整理/調査/レビュー/設計したい」と課題や依頼を受け取った直後 (レビュー自体は graphrag-pr-review / graphrag-design-review の担当 — 本 skill はその上流の知識引き)、触る領域の Decision / Risk / Constraint / 運用知識を `ask` で先に引く (1発で網羅、連打しない)。② 「前回の続き」「引き継ぎ」「過去どう判断した」「なぜこの設計に」と経緯を問われた時。③ 「影響範囲」「どこに波及」と影響伝播を辿りたい時。【書き戻し — 一段落で能動的に (ユーザーの「覚えて」を待たない)】④ 実装/修正が一段落した時・commit 直前 (無言のアクショントリガ — 採用判断/却下案/リスク/運用ハマりを書き戻し、決着した focus の Investigation を閉じる)。⑤ 「Xで行く」「Xはやめる」「今後はY」と結論/却下が確定した時、「覚えて/記録して」と指示された時 (詳細は §Proactive Persistence)。
 ---
 
@@ -25,7 +25,7 @@ Verbs fall into 4 categories: read (`ask`), write (`add-*` / `commit-mutation`),
 This skill is the read/write foundation. Three derived skills review changes and proposals at the concept level using the graph as backbone (shared method: `$REF/graph-review-method.md`). Goal is controllability ("delegate broadly, but don't cross the guardrails"), not QA. They advise, never hard-reject:
 
 - `/graphrag-knowledge:graphrag-design-review` — pre-implementation design review against graph (knowledge axis)
-- `/graphrag-knowledge:graphrag-pr-review` — PR/diff review against graph (crosscut axis + File), detecting concept deltas in 3 tiers
+- `/graphrag-knowledge:graphrag-pr-review` — PR/diff review against graph (crosscut + knowledge axes: boundaries, constraints, rejected options, operational burns, risks, goals), detecting concept deltas in 3 tiers
 - `/graphrag-knowledge:graphrag-review-doc` — generate concept-level explanation doc (HTML) for human reviewers
 
 **Checkpoint / clear handoff lifecycle** (separate from review): `/graphrag-knowledge:graphrag-checkpoint` flushes the live session to the graph before `/compact` (A: work-state → active Investigation `raw_content` + ConversationChunk; B: unpersisted durable knowledge → normal knowledge nodes, wired back via `derived_from`/`led_to`), then fires `checkpoint-mark --investigation <id>` to write a one-shot restore intent into the reserved `__checkpoint__` key of `ask-state.json`. Restore is automatic on `/clear` only — the `clear-restore.mjs` SessionStart hook consumes the one-shot intent (60-min expiry, cwd match) and injects the snapshot. Nothing is injected after compact; run `brief --mode resume` manually to reach the same Investigation.

--- a/plugins/graphrag-knowledge/skills/graphrag-pr-review/SKILL.md
+++ b/plugins/graphrag-knowledge/skills/graphrag-pr-review/SKILL.md
@@ -1,30 +1,41 @@
 ---
 name: graphrag-pr-review
-version: 1.5.0
-description: PR や diff を、AI 自身がグラフ（プロジェクトの永続知識）と照合して概念レベルでレビューし、所見(findings)を返す。「この PR をレビューして」「この差分をグラフ的に見て」「概念が崩れてない?」「方針に反してない?」と、実装後の変更の是非を問われた時に使う（行レベルのバグ探しが主目的ではない）。人間に渡す説明資料(HTML)が欲しい時は graphrag-review-doc、実装前の設計レビューは graphrag-design-review、変更の記録は graphrag-knowledge。スラッシュ: /graphrag-knowledge:graphrag-pr-review
+version: 1.6.0
+description: PR や diff を、AI 自身がグラフ（プロジェクトの永続知識）と照合して概念レベルでレビューし、所見(findings)を返す。境界 (Layer/Concern/Component) の確認だけでなく、Constraint 違反・却下案 (RejectedOption) の再導入・運用知識 (OperationalKnowledge) の再踏襲・Risk の再開・Goal との整合・進行中 Investigation との衝突まで、全知見タイプに diff を尋問する。「この PR をレビューして」「この差分をグラフ的に見て」「概念が崩れてない?」「方針に反してない?」と、実装後の変更の是非を問われた時に使う（行レベルのバグ探しが主目的ではない）。人間に渡す説明資料(HTML)が欲しい時は graphrag-review-doc、実装前の設計レビューは graphrag-design-review、変更の記録は graphrag-knowledge。スラッシュ: /graphrag-knowledge:graphrag-pr-review
 ---
 
-# PR Review (post-implementation, crosscut axis + File / performed by AI)
+# PR Review (post-implementation, crosscut + knowledge axes / performed by AI)
 
 Review at diff time. **The goal is controllability, not QA** (AI is already strong at line-level bug detection; here
-we look at "whether the change crosses the frame of the human-owned concept layer" plus "whether it missed sibling files it should have touched within the frame").
+we check three things: "whether the change crosses the frame of the human-owned concept layer," "whether it trips any recorded knowledge —
+constraints, rejected options, operational burns, open risks, goals, open questions," and "whether it missed sibling files it should have touched within the frame").
+Boundary checking alone wastes the vault — every knowledge type gets its interrogation (method §0-6).
 
-For the shared foundation, CLI invocation, the reverse-lookup skeleton, concept-delta perspectives, and the enforcement level of the 3 tiers,
+For the shared foundation, CLI invocation, the reverse-lookup skeleton, the semantic sweep, the per-type interrogation protocol, and the enforcement level of the 3 tiers,
 **you must first read `${CLAUDE_PLUGIN_ROOT}/references/graph-review-method.md`**. This skill is only a summary of the execution procedure.
 
 ## Input
 
 If `$ARGUMENTS` carries a base/head (e.g. `main...HEAD`), use it; otherwise target the current working diff.
 
-## Procedure (execute method §1.5 → §2 → §2.5 → §3 → §4 verbatim)
+## Procedure (execute method §1.5 → §2 → §2.3 → §2.5 → §3 → §4 verbatim)
 
-0. **Freshness precheck** — execute method §1.5 verbatim. For Files absent from the graph, surface "stale index" at **the top of the findings** (its cause and prescription differ from the binding gap in §4).
+0. **Anchor pass (freshness precheck)** — execute method §1.5 verbatim: one `evidence --types File --limit 1 --neighbors 2` per changed File, **results kept for reuse** (§2 reads the frame off them, §2.5 the impact zone — no re-firing). For Files absent from the graph, surface "stale index" at **the top of the findings** (its cause and prescription differ from the binding gap in §4).
 1. **Get the changed Files**: `git diff --name-only <base>...<head>` (the current working diff if no range is given).
-2. **Build the frame by reverse lookup** — execute method §2 verbatim. One `ask` per area, no repeated firing. **Build the frame at live leaves** (do not anchor on a state-superseded Decision).
-3. **Match against the impact zone by forward expansion** — execute method §2.5 verbatim. Candidates **must be corroborated — actually read the candidate Files and the relevant spots in the diff** (settling for "needs checking" without reading is forbidden). If corroboration shows a norm/constraint is broken, **escalate to ACK-required** and raise the alarm. When candidates are many, you may delegate in parallel to subagents per the delegation clause of method §2.5 (delegation adds a means of execution; it does not shrink the obligation).
-4. **Judge concept deltas** — execute the perspective list of method §3 verbatim. If the diff includes a change to `.graphrag/carving.json`, **escalate the exemption addition into findings for human adjudication**. Concept deltas outside the perspective list are also surfaced explicitly per the "out-of-graph finding" convention (do not silently ignore).
-5. **Classify into 3 tiers** — the table and escalation rules of method §3. **A tier is not a ceiling** — findings judged to cause real harm (breaks, opens a hole, premise-breaking) escalate to ACK-required. A pure defect with no norm node is also surfaced in the red band, explicitly marked as an "out-of-graph finding".
-6. **Frame self-check** — execute method §4 verbatim (do not silently turn a binding gap into "no policy"; suspect a binding gap even when forward expansion yields zero candidates).
+2. **Build the frame by reverse lookup** — execute method §2 verbatim: read landing point / governance / history off the anchor results; the only new retrieval is one area-level `ask` (plus at most one or two single-node deep-dives). **Build the frame at live leaves** (do not anchor on a state-superseded Decision).
+3. **Semantic sweep** — execute method §2.3 verbatim: read the diff, distill the **mechanism digest** and the **intent digest**, then fire the guard sweep
+   (`--types RejectedOption,OperationalKnowledge,Constraint,Risk`) and the direction sweep (`--types Goal,Investigation`) once each.
+   **Do not skip this because the §2 frame already looks rich** — RejectedOption / unbound OperationalKnowledge / Goal / active Investigation are structurally invisible to reverse lookup,
+   and a sweep hit that reverse lookup missed is the binding-gap signature (§4 diagnosis 1).
+4. **Match against the impact zone by forward expansion** — execute method §2.5 verbatim (the impact zone comes from the anchor results' depth-2 — no re-firing). Candidates **must be corroborated — actually read the candidate Files and the relevant spots in the diff** (settling for "needs checking" without reading is forbidden). If corroboration shows a norm/constraint is broken, **escalate to ACK-required** and raise the alarm. When candidates are many, you may delegate in parallel to subagents per the delegation clause of method §2.5 (delegation adds a means of execution; it does not shrink the obligation).
+5. **Interrogate every frame node with the per-type protocol** — execute method §3 verbatim: each node from §2 ∪ §2.3 ∪ §2.5 gets its type's questions put to the diff hunks you read
+   (Constraint = invariant broken or enforcement weakened / RejectedOption = approach reintroduced, "why is it different this time" / Decision = intent silently breached /
+   OperationalKnowledge = burn re-stepped or sanctioned way ignored / Risk = exposure grown or mitigation removed → Risk reopens / Goal = scope creep, roadmap counter-run /
+   active Investigation = open-question collision or settlement / Layer·Concern·Component = boundary checks / has_premise reverse = broken-premise propagation).
+   If the diff includes a change to `.graphrag/carving.json`, **escalate the exemption addition into findings for human adjudication**. Concept deltas outside the list are surfaced per the "out-of-graph finding" convention (do not silently ignore).
+6. **Classify into 3 tiers** — the table and escalation rules of method §3. **A tier is not a ceiling** — findings judged to cause real harm (breaks, opens a hole, premise-breaking, reopens a suppressed Risk) escalate to ACK-required. A pure defect with no norm node is also surfaced in the red band, explicitly marked as an "out-of-graph finding".
+7. **Knowledge-utilization accounting + gap diagnosis** — execute method §4 verbatim: one accounting line per knowledge type (pulled §2/§2.3 / interrogated / findings / drops with reasons);
+   every 0-pulled type gets the three-way diagnosis (binding gap / retrieval gap / genuine absence). Do not silently turn a binding gap into "no policy"; suspect a binding gap even when forward expansion yields zero candidates.
 
 ## Output
 
@@ -32,10 +43,12 @@ If `$ARGUMENTS` carries a base/head (e.g. `main...HEAD`), use it; otherwise targ
 - **Emit the coverage check as its own section** (impact zone − diff, method §2.5): candidates carry propagation path + supporting node id + **a judgment made after reading**.
   Per frame node, record the **accounting** of "number of Files expanded / number of candidates corroborated / dropped candidates and why" —
   "nothing applicable" may be written only with accounting attached. The default is the advisory band; missed siblings that break a norm/constraint also go into the ACK band at the top.
+- **Emit the knowledge-utilization accounting as its own section** (method §4): one line per type, with the three-way diagnosis stated for every empty row. This is what proves the review used the whole vault, not just the boundaries.
 - **Attach advisory to the relevant spot**. Attach **a supporting node id to every finding without exception** (traceable).
 - Cast each finding in the form "possible frame crossing; whether to fix the code or update the policy (graph) side to approve the intent change is for the human to decide", leaving the fix-direction ruling to the human.
 - **Resolution write-back** (method §5): once a human resolves an ACK-required finding by "approving the intent change", propose the approved intent change as a mutation
-  (Decision update / policy-reversal recipe / new RejectedOption) and connect it to the graphrag-knowledge skill's write-back.
+  (Decision update / policy-reversal recipe / new RejectedOption) and connect it to the graphrag-knowledge skill's write-back. The same channel carries the review's other harvest:
+  binding proposals for §4-diagnosed gaps, closing an active Investigation the diff settled, and new knowledge surfaced in a genuinely-absent area.
   Without updating the graph, the same finding recurs next time (alarm fatigue in review).
 - State that line-level bug hunting is not the main target (route to a separate AI code review if needed) and concentrate on the concept layer.
   That said, **do not silently ignore a high-confidence defect you happen to find** — surface it in the red band, explicitly marked as an "out-of-graph finding".

--- a/plugins/graphrag-knowledge/skills/graphrag-review-doc/SKILL.md
+++ b/plugins/graphrag-knowledge/skills/graphrag-review-doc/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: graphrag-review-doc
-version: 1.5.1
-description: 人間が PR レビューするための、概念レベルの説明資料(視覚的な HTML 文書)をグラフ（プロジェクトの永続知識）を背骨に生成する。「この PR のレビュー資料を作って」「概念レベルで説明する文書がほしい」「レビュアー向けに分かりやすく説明して」と、人間レビュアーに渡す資料を求められた時に使う。AI が所見を返すレビュー本体は graphrag-pr-review（本 skill は成果物が HTML 文書である時に選ぶ）。スラッシュ: /graphrag-knowledge:graphrag-review-doc
+version: 1.6.0
+description: 人間が PR レビューするための、概念レベルの説明資料(視覚的な HTML 文書)をグラフ（プロジェクトの永続知識）を背骨に生成する。「この PR のレビュー資料を作って」「概念レベルで説明する文書がほしい」「レビュアー向けに分かりやすく説明して」と、人間レビュアーに渡す資料を求められた時に使う。AI が所見を返すレビュー本体は graphrag-pr-review（本 skill は成果物が HTML 文書である時に選ぶ）、実装前の設計レビューは graphrag-design-review。スラッシュ: /graphrag-knowledge:graphrag-review-doc
 ---
 
 # Human-facing PR Review Doc (explanation-first / HTML)
@@ -9,20 +9,22 @@ description: 人間が PR レビューするための、概念レベルの説明
 Produce a concept-level explanation doc to hand to human reviewers. **Review with only file diffs + a summary becomes a ritual**, so
 build a "concept-altitude map" with the graph as backbone. The first deliverable is not a violation list but an **explanation** (explanation-first, method §0).
 
-For the shared foundation, the reverse-lookup skeleton, and the instruction-text↔schema mapping,
-**you must first read `${CLAUDE_PLUGIN_ROOT}/references/graph-review-method.md`**. The reverse-lookup procedure is shared with pr-review.
+For the shared foundation, the reverse-lookup skeleton, the semantic sweep, and the instruction-text↔schema mapping,
+**you must first read `${CLAUDE_PLUGIN_ROOT}/references/graph-review-method.md`**. The retrieval pipeline is shared with pr-review.
 
 ## Input
 
 If `$ARGUMENTS` carries a base/head, use it; otherwise target the current working diff.
 
-## Procedure (execute method §1.5 → §2 → §2.5 → §3 verbatim)
+## Procedure (execute method §1.5 → §2 → §2.3 → §2.5 → §3 verbatim)
 
 0. **Freshness precheck** — execute method §1.5 verbatim. For Files absent from the graph, state "stale index" as a blind spot at **the top of the doc** (do not hide it).
 1. **Build the frame by reverse lookup** — execute method §2 verbatim (same pipeline as pr-review; pull with `ask` / `evidence`, do not grep).
-2. **Match against the impact zone by forward expansion** — execute method §2.5 verbatim. Candidates **require corroboration — actually read the candidate Files and the diff** (do not conclude from within the graph alone). Note them alongside in the doc's "what was touched", with propagation path + a judgment made after reading.
-3. **Pick up concept deltas** — execute method §3 verbatim. **The doc emits these not as a separate list but as annotations within the relevant section**.
-4. **Assemble the HTML doc**. Visually clear. Cover the graph-derived information and make the explanation hit the core. Write the document text in the conversation language (the audience is the human reviewers, not the LLM).
+2. **Semantic sweep** — execute method §2.3 verbatim (mechanism digest → guard sweep; intent digest → direction sweep). This is what fills the doc's
+   "traps / history / direction" content for knowledge not edge-bound to the touched Files — without it the doc can only show what was already wired.
+3. **Match against the impact zone by forward expansion** — execute method §2.5 verbatim. Candidates **require corroboration — actually read the candidate Files and the diff** (do not conclude from within the graph alone). Note them alongside in the doc's "what was touched", with propagation path + a judgment made after reading.
+4. **Pick up concept deltas** — execute the per-type interrogation of method §3 verbatim. **The doc emits these not as a separate list but as annotations within the relevant section**.
+5. **Assemble the HTML doc**. Visually clear. Cover the graph-derived information and make the explanation hit the core. Write the document text in the conversation language (the audience is the human reviewers, not the LLM).
 
 ## Doc structure (graph as backbone)
 
@@ -31,25 +33,28 @@ Productized from the user's real-world review instruction (the ConversationChunk
 - **Overview**: what this PR changes conceptually (1–2 paragraphs).
 - **Affected structures** (crosscut axis): enumerate the **Layer / Component / Concern** touched,
   what each is, and how this PR changes it. Quote each node's summary (= norm / design intent).
-- **Each structure's issues / policy / traps / history** (knowledge axis, woven into the section):
+- **Each structure's issues / policy / traps / history / direction** (knowledge axis, woven into the section):
   - Issues = Risks that `risks_in` that area / Constraints in tension / unmet Goals
   - Policy = the governing Decision / Constraint (framed as **does the change satisfy this?**; e.g. "this area is governed by 'errors are shown to the user'. Does this change satisfy it?")
-  - Traps = Risk / OperationalKnowledge
-  - Past history = RejectedOption / supersedes chain
-- **Concept-delta annotations**: embed the divergences picked up in step 3 as prominent callouts within the relevant section
+  - Traps = Risk / OperationalKnowledge (including sweep-found burns about the same mechanism from elsewhere — quote the pitfall next to the hunk that risks re-stepping it)
+  - Past history = RejectedOption / supersedes chain (a sweep-found RejectedOption matching the PR's approach is prime doc material: quote the original rejection reason)
+  - Direction = which live Goal this serves / which active Investigation it touches or settles (from the §2.3 direction sweep)
+- **Concept-delta annotations**: embed the divergences picked up in step 4 as prominent callouts within the relevant section
   (ACK-required = red banner "needs checking", advisory = supplementary yellow callout).
 - **What was touched**: show the changed Files tied to the structures above (Layer/Component/Concern).
-  **Files that belong to the same structure but were not touched** (missed-sibling candidates from step 2) are noted alongside with their propagation path
+  **Files that belong to the same structure but were not touched** (missed-sibling candidates from step 3) are noted alongside with their propagation path
   (e.g. "2 of the 3 Files in this Concern are touched. I read the remaining one — still on the old error handling with no retry support, inconsistent with the post-change norm. Follow-up is likely needed").
   Writing only "impact needs checking" without reading is forbidden (method §2.5-3 corroboration). For nothing applicable, state "none" explicitly with accounting (number expanded / number corroborated).
   Missed siblings judged to break a norm/constraint (real harm results) are treated as a red banner "needs checking" (method §3 escalation rule).
+- **Graph coverage footer**: a compact rendition of the knowledge-utilization accounting (method §4) — per knowledge type, what was consulted and what came up empty,
+  with binding/retrieval gaps stated honestly (human reviewers deserve to know where the map has blank spots).
 
 ## Invariants (method §0)
 
 - **traceable**: every policy/history claim in the doc must trace to a human-approved knowledge node. Attach a supporting node id (or vault link) to each statement. Do not let AI free-composition get an approval stamp.
-- **Frame self-check** (method §4): if there is an area where no governing policy can be pulled, honestly state in the doc "this area has no policy binding in the graph (suspected binding gap; a spot where review accuracy drops)". Do not hide it.
+- **Gap honesty** (method §4): if a knowledge type or an area comes up empty, state it in the doc — "this area has no policy binding in the graph (suspected binding gap; a spot where review accuracy drops)" — instead of hiding it. Do not silently turn a binding gap into "no policy".
 - This is an advisory document, not a verdict. Write it so that the fix-direction ruling (fix the code or update the policy) is left to the human reviewer.
 
 ## Output location
 
-Write the HTML to a single file (default name: `review-doc-<branch>.html` in the working directory; a name not to be confused with pr-review's findings output). Tell the user the output path.
+Write the HTML to a single file (default name: `review-doc-<branch>.html` in the working directory). Tell the user the output path.


### PR DESCRIPTION
## 概要

レビュー 3 スキル (pr-review / design-review / review-doc) が Concern/Layer/Component の境界チェックに偏り、Constraint・RejectedOption・OperationalKnowledge・Risk・Goal・Investigation を使い切れていなかった問題を、共有 method (`graph-review-method.md`) の再設計で解消する。

## 何が問題だったか

- 逆引き (§2) は **エッジ走行** なので、変更 File にバインドされた知見しか届かない
  - RejectedOption は File へのエッジをほぼ持たず (rejected_in→Investigation / ←supersedes)、再導入検出は **approach 一致であって location 一致ではない** — 別ファイルで同じ却下案を再実装すると逆引きでは永遠に出会えない
  - Goal は File エッジ皆無、active Investigation もほぼ無し → scope creep / 進行中調査との衝突が構造的に不可視
  - Decision 越しの Constraint は 2 hop 超で近傍打ち切りに落ちる
- 旧 §3 の観点リストに各タイプは載っていたが、**フレームに入らなかったノードには観点が発火しない** (検索が届かない知見は無言スルー、「0件」と「未検索」の区別も不能)
- design-review に至っては OperationalKnowledge / Risk / Investigation の観点が皆無だった

## 変更内容

**`references/graph-review-method.md`** (共有 method):
- **新 §2.3 Semantic sweep**: diff から mechanism/intent digest を蒸留し、`evidence --types` で guard 掃引 (RejectedOption,OK,Constraint,Risk) + direction 掃引 (Goal,Investigation) を各 1 発。バインド非依存の網。**sweep が拾い逆引きが拾えない = バインド欠落の署名**として §4 診断に接続
- **§3 をタイプ別尋問プロトコルに再構成**: フレーム全ノードにタイプ固有質問を diff へ強制 (Constraint=不変条件の破り/骨抜き、RejectedOption=「今回はなぜ違う」の要求、OK=再踏襲+作法準拠の両方向、Risk=reduces_risk 撤去による再開、Goal=scope creep/roadmap 逆走、active Investigation=衝突/決着)。「境界チェックはリストの一項目であってリストではない」
- **§4 を知見活用会計に一般化**: タイプ別に 取得/尋問/所見 を計上、0 件は三択診断 (バインド欠落/検索語ミス/真の不在)。レビューがグラフの育成側にも回る (§5 write-back に結線提案・Investigation 閉じ・新知見捕捉を追加)

**既存指示の作り込み不足も修正** (ユーザー指摘 + skill-reviewer エージェント検証で検出):
- §1.5/§2/§2.5 が別々の検索として書かれ重複発火を誘発していた → **anchor 呼び出し 1 本/File** (`evidence --types File --limit 1 --neighbors 2`) に統一し、3 セクションが結果を読み回す構成へ
- §2.5 の「**constrains の宛先は File のみ**」が schema (Decision|File|OK) と矛盾 → 修正 (vault の既存 Decision `review-percandidate-pull-permanent` とも整合)
- 低確信時に index 遅れをバインド欠落と誤ラベルする分岐を除去 (§1.5 の path 照合に置換)
- review-doc の存在しない出力ファイルへの言及など残骸の掃除

**スキル**: pr-review 1.6.0 / design-review 1.3.0 / review-doc 1.6.0 (方向軸 + カバレッジ開示追加) / graphrag-knowledge 4.9.2 (紹介行) / plugin 1.18.0

## 検証

- §番号クロスリファレンス (3 スキル → method) 全解決を機械確認
- skill-reviewer エージェントでレビュー済み (指摘の major 1 件 = constrains 矛盾、minor 4 件すべて修正済み)
- `--types` の型名は canonical 名のみ使用 (CLI 実装 `types.has(node.type)` は exact match) を実装読みで確認
- 変更の背後の判断は vault に書き戻し済み (Decision 1 + RejectedOption 2 + OK 1、既存 Risk `instruction-doc-contradiction-drift` に reduces_risk 結線)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NN2S87SrQwvU3sLztb1mVj